### PR TITLE
Accept missing "properties" in config json

### DIFF
--- a/lib/osgi_config/config_list.erb
+++ b/lib/osgi_config/config_list.erb
@@ -98,7 +98,7 @@ config_details.sort_by {|pid| pid.values_at("title", "pid")}.each_with_index do 
   <p>Description = <%= eh(config["description"]) %></p>
   
   <%
-    properties = config["properties"]
+    properties = config["properties"] || {}
     properties.each_pair do |param_key, param|
   %>
     <section>


### PR DESCRIPTION
Accept missing "properties" in config json (e.g. AEM 6.1 com.adobe.cq.social.activitystreams.impl.SocialActivityManagerImpl.json)